### PR TITLE
Fix(Config): Make configuration loading and saving robust

### DIFF
--- a/Configuration.gs
+++ b/Configuration.gs
@@ -20,12 +20,16 @@ function getProperty(properties, key, defaultValue = null) {
     if (value === null) {
         return defaultValue;
     }
+    // Grâce à la nouvelle logique de sauvegarde, on sait que toutes les propriétés
+    // sont stockées en format JSON. On peut donc parser directement.
     try {
-        // Tente de parser en tant que JSON. Si ça échoue, retourne la chaîne.
-        // Cela gère les objets, tableaux, booléens et nombres stockés en tant que chaînes.
         return JSON.parse(value);
     } catch (e) {
-        return value; // Retourne la chaîne si ce n'est pas un JSON valide.
+        // Si le parse échoue, c'est une erreur inattendue.
+        // Cela peut arriver si les propriétés ont été modifiées manuellement avec un format invalide.
+        Logger.log(`Erreur de parsing JSON pour la clé '${key}'. Valeur: '${value}'. Erreur: ${e.message}`);
+        // On retourne la valeur par défaut pour éviter un crash complet.
+        return defaultValue;
     }
 }
 

--- a/Setup.gs
+++ b/Setup.gs
@@ -99,12 +99,11 @@ function migrerConfigurationVersProperties() {
     const clesSauvegardees = [];
     for (const key in config) {
       if (Object.prototype.hasOwnProperty.call(config, key)) {
-        let value = config[key];
-        // Stringify les objets et tableaux pour les stocker correctement
-        if (typeof value === 'object' && value !== null) {
-          value = JSON.stringify(value);
-        }
-        properties.setProperty(key, value);
+        const value = config[key];
+        // On utilise TOUJOURS JSON.stringify pour garantir que le type est préservé
+        // (ex: false ne devient pas la chaîne "false" mais reste un booléen après parse)
+        const valueAsString = JSON.stringify(value);
+        properties.setProperty(key, valueAsString);
         clesSauvegardees.push(key);
       }
     }


### PR DESCRIPTION
The previous implementation had issues with type preservation when storing and retrieving configuration values from PropertiesService. Booleans, numbers, and strings were handled inconsistently.

This change implements a more robust system:
- All values are now encoded as JSON strings using `JSON.stringify` before being saved.
- All values are now decoded using `JSON.parse` upon retrieval.

This ensures that data types are always preserved, fixing the setup issue where the configuration would fail to load correctly.