### PR TITLE
Fix(Maintenance): Prevent crash when getting UI in trigger

### DIFF
--- a/Maintenance.html
+++ b/Maintenance.html
@@ -61,22 +61,29 @@ function notifyAdminWithThrottle(typeErreur, sujet, corps) {
 // =================================================================
 
 function sauvegarderCodeProjet() {
-  logAdminAction("Sauvegarde manuelle du code", "Démarré");
-  const ui = SpreadsheetApp.getUi();
-  try {
-    const fichiers = recupererTousLesFichiersProjet();
-    if (!fichiers) {
-      throw new Error("Impossible de récupérer les fichiers du projet. L'API Google Apps Script est peut-être désactivée.");
-    }
-    
-    const horodatage = formaterDatePersonnalise(new Date(), "yyyy-MM-dd'_'HH'h'mm");
-    const nomDossierSauvegarde = `Sauvegarde Code ${horodatage}`;
-    
-    const dossierProjet = DriveApp.getFileById(CONFIG.ID_FEUILLE_CALCUL).getParents().next();
-    const dossierParentSauvegardes = obtenirOuCreerDossier(dossierProjet, "Sauvegardes Code");
-    const dossierSauvegarde = dossierParentSauvegardes.createFolder(nomDossierSauvegarde);
-    
-    fichiers.forEach(fichier => {
+  logAdminAction("Sauvegarde du code", "Démarré");
+  let ui;
+  try {
+    ui = SpreadsheetApp.getUi();
+  } catch (e) {
+    // UI non disponible (ex: exécution par déclencheur), on continue sans UI.
+    ui = null;
+  }
+
+  try {
+    const fichiers = recupererTousLesFichiersProjet();
+    if (!fichiers) {
+      throw new Error("Impossible de récupérer les fichiers du projet. L'API Google Apps Script est peut-être désactivée.");
+    }
+
+    const horodatage = formaterDatePersonnalise(new Date(), "yyyy-MM-dd'_'HH'h'mm");
+    const nomDossierSauvegarde = `Sauvegarde Code ${horodatage}`;
+
+    const dossierProjet = DriveApp.getFileById(CONFIG.ID_FEUILLE_CALCUL).getParents().next();
+    const dossierParentSauvegardes = obtenirOuCreerDossier(dossierProjet, "Sauvegardes Code");
+    const dossierSauvegarde = dossierParentSauvegardes.createFolder(nomDossierSauvegarde);
+
+    fichiers.forEach(fichier => {
       let nomFichier;
       switch (fichier.type) {
         case 'SERVER_JS':
@@ -89,21 +96,29 @@ function sauvegarderCodeProjet() {
           nomFichier = `${fichier.name}.json`;
           break;
         default:
-          // Fallback pour les types de fichiers inattendus, avec log.
           nomFichier = `${fichier.name}.txt`;
           Logger.log(`Type de fichier inconnu durant la sauvegarde : ${fichier.type}. Fichier "${fichier.name}" sauvegardé comme .txt`);
           break;
       }
-      dossierSauvegarde.createFile(nomFichier, fichier.source, MimeType.PLAIN_TEXT);
-    });
+      dossierSauvegarde.createFile(nomFichier, fichier.source, MimeType.PLAIN_TEXT);
+    });
 
-    ui.alert('Sauvegarde Réussie', `Le projet a été sauvegardé dans le dossier :\n"${nomDossierSauvegarde}"`, ui.ButtonSet.OK);
-    logAdminAction("Sauvegarde manuelle du code", "Succès");
-  } catch (e) {
-    Logger.log(`Erreur de sauvegarde manuelle : ${e.stack}`);
-    ui.alert('Erreur de sauvegarde', `Une erreur est survenue : ${e.message}`, ui.ButtonSet.OK);
-    logAdminAction("Sauvegarde manuelle du code", `Échec : ${e.message}`);
-  }
+    const messageSucces = `Le projet a été sauvegardé dans le dossier : "${nomDossierSauvegarde}"`;
+    if (ui) {
+      ui.alert('Sauvegarde Réussie', messageSucces, ui.ButtonSet.OK);
+    } else {
+      Logger.log(messageSucces);
+    }
+    logAdminAction("Sauvegarde du code", "Succès");
+
+  } catch (e) {
+    const messageErreur = `Une erreur est survenue lors de la sauvegarde du code : ${e.message}`;
+    Logger.log(`Erreur de sauvegarde : ${e.stack}`);
+    if (ui) {
+      ui.alert('Erreur de sauvegarde', messageErreur, ui.ButtonSet.OK);
+    }
+    logAdminAction("Sauvegarde du code", `Échec : ${e.message}`);
+  }
 }
 
 function sauvegarderDonnees() {


### PR DESCRIPTION
The `sauvegarderCodeProjet` function was attempting to access the Spreadsheet UI via `SpreadsheetApp.getUi()`. This function was being called by a time-based trigger, which runs in a context where no UI is available, causing an exception.

I fixed this issue by wrapping the `getUi()` call in a try-catch block. If a UI is available, it is used to display alerts to you. If the call fails (as it does in a trigger), the UI-related code is skipped, and messages are logged to the Apps Script logger instead. This makes the function safe to run in both manual and triggered contexts.